### PR TITLE
Added missing %s in the $server connection string for the $database name

### DIFF
--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -125,7 +125,7 @@ abstract class AbstractCommand extends Command
         }
 
         $server = sprintf(
-            "mongodb://%s%s:%s",
+            "mongodb://%s%s:%s%s",
             $credentials,
             (isset($params['host']) ? $params['host'] : 'localhost'),
             (isset($params['port']) ? $params['port'] : '27017'),


### PR DESCRIPTION
It was defaulting to "admin" database and was throwing authentication exception.