### PR TITLE
Remove deprecated notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "antimattr/test-case": "~1.0@stable",
         "phpunit/phpunit": "~4.0",
-        "fabpot/php-cs-fixer": "0.5.*@dev",
+        "fabpot/php-cs-fixer": "~1.1",
         "mikey179/vfsStream": "1.*"
     },
     "minimum-stability": "dev",
@@ -26,8 +26,7 @@
         "psr-0": { "AntiMattr\\MongoDB\\Migrations\\": "src/" }
     },
     "autoload-dev": {
-        "psr-0": { 
-            "AntiMattr\\TestCase\\": "vendor/antimattr/test-case/src",
+        "psr-0": {
             "AntiMattr\\Tests\\MongoDB\\Migrations\\": "tests/"
         }
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit colors="true" bootstrap="tests/bootstrap.php">
     <testsuites>
         <testsuite name="Test Suite">
             <directory>./tests/</directory>

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -66,7 +66,7 @@ EOT
         if (!$input->isInteractive()) {
             $version->execute($direction);
         } else {
-            $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/n)</question>', false);
+            $confirmation = $this->getHelper('question')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/n)</question>', false);
             if ($confirmation === true) {
                 $version->execute($direction);
             } else {

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -81,7 +81,7 @@ EOT
             }
 
             if (! $noInteraction) {
-                $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>Are you sure you wish to continue? (y/n)</question>', false);
+                $confirmation = $this->getHelper('question')->askConfirmation($output, '<question>Are you sure you wish to continue? (y/n)</question>', false);
                 if (! $confirmation) {
                     $output->writeln('<error>Migration cancelled!</error>');
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
When I execute the migration scripts I have deprecated notices from Symfony

```
"Symfony\Component\Console\Helper\DialogHelper" is deprecated since version 2.5 and will be removed in 3.0. Use "Symfony\Component\Console\Helper\QuestionHelper" ins
tead. File /usr/share/tws/vendor/symfony/console/Helper/HelperSet.php Line:83 
```